### PR TITLE
add shiny and legendary scoreboards

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.4.0
+mod_version=1.5.0
 maven_group=com.scoredex
 archives_base_name=scoredex
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.5.0
+mod_version=1.5.1
 maven_group=com.scoredex
 archives_base_name=scoredex
 

--- a/src/main/java/com/scoredex/Scoredex.java
+++ b/src/main/java/com/scoredex/Scoredex.java
@@ -59,7 +59,7 @@ public class Scoredex implements ModInitializer {
     private BufferedImage currentLegendaryScoreboardImage;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private MinecraftServer minecraftServer;
-    private final List<String> legendaries = new ArrayList<>();
+    private final Set<String> legendaries = new HashSet<>();
 
     private static class Config {
         int port = DEFAULT_PORT;
@@ -305,15 +305,26 @@ public class Scoredex implements ModInitializer {
                             if (playerName != null) {
                                 JsonObject advancementData = data.getAsJsonObject("advancementData");
                                 if (advancementData != null && advancementData.has("totalCaptureCount")) {
-                                    int capturedCount = advancementData.get("totalCaptureCount").getAsInt();
-                                    int shinyCount = advancementData.get("totalShinyCaptureCount").getAsInt();
 
                                     JsonObject aspectsCollected = advancementData.getAsJsonObject("aspectsCollected");
+                                    int capturedCount = 0;
+                                    int shinyCount = advancementData.get("totalShinyCaptureCount").getAsInt();
                                     int legendaryCount = 0;
-                                    for (String legendaryKey : legendaries) {
-                                        if (aspectsCollected.has(legendaryKey)) {
-                                            legendaryCount++;
+
+                                    List<String> genders = List.of("genderless", "male", "female");
+                                    for (String key : aspectsCollected.keySet()) {
+                                        if (legendaries.contains(key)) legendaryCount++;
+
+                                        int i = 0;
+                                        for (JsonElement v : aspectsCollected.get(key).getAsJsonArray()) {
+                                            String value = v.getAsString().trim().toLowerCase();
+                                            LOGGER.info("Raw value: '" + v.getAsString() + "'");
+                                            if (!genders.contains(value)) {
+                                                i++;
+                                            }
                                         }
+                                        if (i == 0) i = 1;
+                                        capturedCount += i;
                                     }
 
                                     scores.add(new PlayerScore(playerName, capturedCount, shinyCount, legendaryCount));

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,7 @@
 	"name": "Scoredex",
 	"description": "Un scoreboard pour Cobblemon",
 	"authors": [
-		"Tellsanguis"
+		"Tellsanguis", "Monkey Prince"
 	],
 	"contact": {
 		"homepage": "https://fabricmc.net/",


### PR DESCRIPTION
Ajout de 4 endpoints pour afficher le nombre de shinies / légendaires capturés:
- http://localhost:8080/shiny.png
- http://localhost:8080/legendary.png
- http://localhost:8080/api/shiny
- http://localhost:8080/api/legendary

Les noms des nouveaux scoreboards peuvent être changés avec les valeurs `shinyImageTitle` et `legendaryImageTitle` dans la config.